### PR TITLE
Added link targets and swapped contribution type and year

### DIFF
--- a/app/about.njk
+++ b/app/about.njk
@@ -22,7 +22,7 @@
     </p>
     <p>
       Formerly I was a part of <a href="https://material.io/design" target="_blank" rel="noopener noreferrer"
-          >Google’s Material Design team</a, where I
+          >Google’s Material Design team</a>, where I
       contributed to Google's scalable and inclusive design system, as well as
       <a href="https://www.google.com/travel/" target="_blank" rel="noopener noreferrer"
           >Google Travel</a, creating user-centered travel experiences.

--- a/app/about.njk
+++ b/app/about.njk
@@ -25,7 +25,7 @@
           >Google’s Material Design team</a>, where I
       contributed to Google's scalable and inclusive design system, as well as
       <a href="https://www.google.com/travel/" target="_blank" rel="noopener noreferrer"
-          >Google Travel</a, creating user-centered travel experiences.
+          >Google Travel</a>, creating user-centered travel experiences.
     </p>
     <p>
       Currently I'm a freelance Product Designer and Co-founder of Felt, a

--- a/app/about.njk
+++ b/app/about.njk
@@ -21,9 +21,11 @@
       identities, and design systems.
     </p>
     <p>
-      Formerly I was a part of Google’s Material Design team, where I
+      Formerly I was a part of <a href="https://material.io/design" target="_blank" rel="noopener noreferrer"
+          >Google’s Material Design team</a, where I
       contributed to Google's scalable and inclusive design system, as well as
-      Google Travel, creating user-centered travel experiences.
+      <a href="https://www.google.com/travel/" target="_blank" rel="noopener noreferrer"
+          >Google Travel</a, creating user-centered travel experiences.
     </p>
     <p>
       Currently I'm a freelance Product Designer and Co-founder of Felt, a
@@ -49,13 +51,13 @@
     <h3>Get in touch</h3>
     <ul>
       <li>
-        <a href="mailto:hello@megananderson.com">hello@megananderson.com</a>
+        <a href="mailto:megan@manderson.design">megan@manderson.design</a>
       </li>
       <li>
         <a href="tel:+16507889516">+1 (650) 788-9516</a>
       </li>
       <li>
-        <a href="https://www.linkedin.com/in/andersonmeganchristine/"
+        <a href="https://www.linkedin.com/in/andersonmeganchristine/" target="_blank" rel="noopener noreferrer"
           >LinkedIn</a
         >
       </li>
@@ -109,41 +111,41 @@
   <h3>Community</h3>
   <ul>
     <li class="experience-item">
-      <div class="contribution-type">U.S. Patent</div>
+      <div class="contribution-type">2018</div>
       <h4>
-        <a href="https://www.patentguru.com/US2021011690A1">US2021011690A1</a>,
+        <a href="https://www.patentguru.com/US2021011690A1" target="_blank" rel="noopener noreferrer">US2021011690A1</a>,
         “Design system for creating graphical content”
       </h4>
-      <div class="year">2018</div>
+      <div class="year">U.S. Patent</div>
     </li>
     <li class="experience-item">
-      <div class="contribution-type">U.S. Patent</div>
+      <div class="contribution-type">2018</div>
       <h4>
-        <a href="https://www.patentguru.com/USD854031S1">USD854031S1</a>,
+        <a href="https://www.patentguru.com/USD854031S1" target="_blank" rel="noopener noreferrer">USD854031S1</a>,
         “Display screen with animated graphical user interface”
       </h4>
-      <div class="year">2018</div>
+      <div class="year">U.S. Patent</div>
     </li>
     <li class="experience-item">
-      <div class="contribution-type">Conference</div>
+      <div class="contribution-type">2018</div>
       <h4>
-        Google I/O, Product Demo Booth &amp; Material Design Reviewer
+        <a href="https://events.google.com/io2018/" target="_blank" rel="noopener noreferrer">Google I/O 2018</a>, Product Demo Booth &amp; Material Design Reviewer
       </h4>
-      <div class="year">2018</div>
+      <div class="year">Conference</div>
     </li>
     <li class="experience-item">
-      <div class="contribution-type">Research Team</div>
+      <div class="contribution-type">2017</div>
       <h4>
         Google, Accessibility & Inclusive Design Study team member
       </h4>
-      <div class="year">2017</div>
+      <div class="year">Research Team</div>
     </li>
     <li class="experience-item">
-      <div class="contribution-type">Conference</div>
+      <div class="contribution-type">2016</div>
       <h4>
-        Google I/O, Material Design Reviewer
+        Google I/O 2016 , Material Design Reviewer
       </h4>
-      <div class="year">2016</div>
+      <div class="year">Conference</div>
     </li>
   </ul>
 </section>


### PR DESCRIPTION
To make the page consistent where dates are on the left as overlines, I swapped _contribution type_ and _year_ content